### PR TITLE
ci: semantic pr - allow running on external prs

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -5,11 +5,15 @@ concurrency:
   group: Semantic-PR-${{ github.head_ref }}
   cancel-in-progress: true
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited
       - reopened
+
+permissions:
+  pull-requests: read
+
 jobs:
   semantic-pr:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Changing the trigger to allow this workflow to run on PRs that originated from forked repos