### PR TITLE
fix: Bug fixes - embed, streaming response, request retry rename

### DIFF
--- a/ai21/http_client/async_http_client.py
+++ b/ai21/http_client/async_http_client.py
@@ -55,7 +55,7 @@ class AsyncAI21HTTPClient(BaseHttpClient[httpx.AsyncClient, AsyncStream[Any]]):
             wait=wait_exponential(multiplier=RETRY_BACK_OFF_FACTOR, min=TIME_BETWEEN_RETRIES),
             retry=retry_if_result(self._should_retry),
             stop=stop_after_attempt(self._num_retries),
-        )(self._request)
+        )(self._run_request)
         self._streaming_decoder = _SSEDecoder()
 
     async def execute_http_request(
@@ -112,7 +112,7 @@ class AsyncAI21HTTPClient(BaseHttpClient[httpx.AsyncClient, AsyncStream[Any]]):
 
         return response
 
-    async def _request(self, options: RequestOptions) -> httpx.Response:
+    async def _run_request(self, options: RequestOptions) -> httpx.Response:
         request = self._build_request(options)
 
         _logger.debug(f"Calling {request.method} {request.url} {request.headers}, {options.body}")

--- a/ai21/http_client/async_http_client.py
+++ b/ai21/http_client/async_http_client.py
@@ -103,7 +103,12 @@ class AsyncAI21HTTPClient(BaseHttpClient[httpx.AsyncClient, AsyncStream[Any]]):
             logger.error(
                 f"Calling {method} {self._base_url} failed with a non-200 response code: {response.status_code}"
             )
-            handle_non_success_response(response.status_code, response.text)
+
+            if stream:
+                details = self._extract_streaming_error_details(response)
+                handle_non_success_response(response.status_code, details)
+            else:
+                handle_non_success_response(response.status_code, response.text)
 
         return response
 

--- a/ai21/http_client/base_http_client.py
+++ b/ai21/http_client/base_http_client.py
@@ -173,4 +173,7 @@ class BaseHttpClient(ABC, Generic[_HttpxClientT, _DefaultStreamT]):
         return options.url
 
     def _extract_streaming_error_details(self, response: httpx.Response) -> str:
-        return response.read().decode("utf-8")
+        try:
+            return response.read().decode("utf-8")
+        except Exception:
+            return "could not extract streaming error details"

--- a/ai21/http_client/base_http_client.py
+++ b/ai21/http_client/base_http_client.py
@@ -171,3 +171,6 @@ class BaseHttpClient(ABC, Generic[_HttpxClientT, _DefaultStreamT]):
             return f"{options.url}{options.path}"
 
         return options.url
+
+    def _extract_streaming_error_details(self, response: httpx.Response) -> str:
+        return response.read().decode("utf-8")

--- a/ai21/http_client/base_http_client.py
+++ b/ai21/http_client/base_http_client.py
@@ -118,7 +118,7 @@ class BaseHttpClient(ABC, Generic[_HttpxClientT, _DefaultStreamT]):
         pass
 
     @abstractmethod
-    def _request(
+    def _run_request(
         self,
         options: RequestOptions,
     ) -> httpx.Response:

--- a/ai21/http_client/http_client.py
+++ b/ai21/http_client/http_client.py
@@ -102,7 +102,12 @@ class AI21HTTPClient(BaseHttpClient[httpx.Client, Stream[Any]]):
                 f"Calling {method} {self._base_url} failed with a non-200 "
                 f"response code: {response.status_code} headers: {response.headers}"
             )
-            handle_non_success_response(response.status_code, response.text)
+
+            if stream:
+                details = self._extract_streaming_error_details(response)
+                handle_non_success_response(response.status_code, details)
+            else:
+                handle_non_success_response(response.status_code, response.text)
 
         return response
 

--- a/ai21/http_client/http_client.py
+++ b/ai21/http_client/http_client.py
@@ -81,7 +81,7 @@ class AI21HTTPClient(BaseHttpClient[httpx.Client, Stream[Any]]):
                 timeout=self._timeout_sec,
                 url=self._base_url,
             )
-            response = self._run_request(options=options)
+            response = self._request(options=options)
         except RetryError as retry_error:
             last_attempt = retry_error.last_attempt
 

--- a/ai21/http_client/http_client.py
+++ b/ai21/http_client/http_client.py
@@ -54,7 +54,7 @@ class AI21HTTPClient(BaseHttpClient[httpx.Client, Stream[Any]]):
             wait=wait_exponential(multiplier=RETRY_BACK_OFF_FACTOR, min=TIME_BETWEEN_RETRIES),
             retry=retry_if_result(self._should_retry),
             stop=stop_after_attempt(self._num_retries),
-        )(self._request)
+        )(self._run_request)
         self._streaming_decoder = _SSEDecoder()
 
     def execute_http_request(
@@ -81,7 +81,7 @@ class AI21HTTPClient(BaseHttpClient[httpx.Client, Stream[Any]]):
                 timeout=self._timeout_sec,
                 url=self._base_url,
             )
-            response = self._request(options=options)
+            response = self._run_request(options=options)
         except RetryError as retry_error:
             last_attempt = retry_error.last_attempt
 
@@ -111,7 +111,7 @@ class AI21HTTPClient(BaseHttpClient[httpx.Client, Stream[Any]]):
 
         return response
 
-    def _request(self, options: RequestOptions) -> httpx.Response:
+    def _run_request(self, options: RequestOptions) -> httpx.Response:
         request = self._build_request(options)
 
         _logger.debug(f"Calling {request.method} {request.url} {request.headers}, {options.body}")

--- a/ai21/models/responses/embed_response.py
+++ b/ai21/models/responses/embed_response.py
@@ -6,6 +6,9 @@ from ai21.models.ai21_base_model import AI21BaseModel
 class EmbedResult(AI21BaseModel):
     embedding: List[float]
 
+    def __init__(self, embedding: List[float], **kwargs):
+        super().__init__(embedding=embedding, **kwargs)
+
 
 class EmbedResponse(AI21BaseModel):
     id: str

--- a/ai21/models/responses/embed_response.py
+++ b/ai21/models/responses/embed_response.py
@@ -6,8 +6,8 @@ from ai21.models.ai21_base_model import AI21BaseModel
 class EmbedResult(AI21BaseModel):
     embedding: List[float]
 
-    def __init__(self, embedding: List[float], **kwargs):
-        super().__init__(embedding=embedding, **kwargs)
+    def __init__(self, embedding: List[float]):
+        super().__init__(embedding=embedding)
 
 
 class EmbedResponse(AI21BaseModel):


### PR DESCRIPTION
* Allow positional argument in EmbedResult for backward compatibility
* Handle streaming response for non-200 status code
* Rename _request function to avoid mypy redefinition error